### PR TITLE
Add copyright/license info for Keyman.py

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -264,6 +264,10 @@ Copyright: 2009, 2011-2014, marmuta <marmvta@gmail.com>
   2010, 2013, Francesco Fumanti <francesco.fumanti@gmx.net>
 License: GPL-3+
 
+Files: Onboard/Keyman.py
+Copyright: 2018 Daniel Glassey <dglassey@gmail.com>
+License: GPL-3+
+
 Files: data/*
 Copyright: 2011-2015, marmuta <marmvta@gmail.com>
   2012, Gerd Kohlberger <lowfi@chello.at>


### PR DESCRIPTION
Add missing piece of information that's needed for Debian packaging